### PR TITLE
fix: Refactor app bar to PreferredSizeWidget

### DIFF
--- a/packages/mirai/lib/src/action/mirai_action_parser.dart
+++ b/packages/mirai/lib/src/action/mirai_action_parser.dart
@@ -12,16 +12,18 @@ extension MiraiActionParser on MiraiAction? {
       }
       switch (this?.actionType ?? ActionType.none) {
         case ActionType.navigate:
-          Widget widget;
+          Widget? widget;
           if (this!.widgetJson != null) {
             widget = Mirai.fromJson(this!.widgetJson, context);
 
-            return MiraiNavigator.navigate(
-              context: context,
-              navigationType: this?.navigationType ?? NavigationType.screen,
-              navigationStyle: this?.navigationStyle ?? NavigationStyle.push,
-              widget: widget,
-            );
+            if (widget != null) {
+              return MiraiNavigator.navigate(
+                context: context,
+                navigationType: this?.navigationType ?? NavigationType.screen,
+                navigationStyle: this?.navigationStyle ?? NavigationStyle.push,
+                widget: widget,
+              );
+            }
           } else if (this?.request != null) {
             widget = Mirai.fromNetwork(this!.request!);
 
@@ -34,7 +36,7 @@ extension MiraiActionParser on MiraiAction? {
           } else if (this?.assetPath != null) {
             widget = await Mirai.fromAssets(this!.assetPath!, context);
 
-            if (context.mounted) {
+            if (context.mounted && widget != null) {
               return MiraiNavigator.navigate(
                 context: context,
                 navigationType: this?.navigationType ?? NavigationType.screen,

--- a/packages/mirai/lib/src/framework/mirai.dart
+++ b/packages/mirai/lib/src/framework/mirai.dart
@@ -54,7 +54,7 @@ class Mirai {
     MiraiRegistry.instance.registerAll(_parsers);
   }
 
-  static Widget fromJson(Map<String, dynamic>? json, BuildContext context) {
+  static Widget? fromJson(Map<String, dynamic>? json, BuildContext context) {
     try {
       if (json != null) {
         String widgetType = json['type'];
@@ -69,8 +69,7 @@ class Mirai {
     } catch (e) {
       Log.e(e);
     }
-
-    return const SizedBox();
+    return null;
   }
 
   static Widget fromNetwork(
@@ -92,7 +91,7 @@ class Mirai {
           case ConnectionState.done:
             if (snapshot.hasData) {
               final json = jsonDecode(snapshot.data.toString());
-              return Mirai.fromJson(json, context);
+              return Mirai.fromJson(json, context) ?? const SizedBox();
             } else if (snapshot.hasError) {
               Log.e(snapshot.error);
               if (errorWidget != null) {
@@ -109,7 +108,7 @@ class Mirai {
     );
   }
 
-  static Future<Widget> fromAssets(
+  static Future<Widget?> fromAssets(
     String assetPath,
     BuildContext context,
   ) async {
@@ -120,6 +119,6 @@ class Mirai {
       return fromJson(jsonData, context);
     }
 
-    return const SizedBox();
+    return null;
   }
 }

--- a/packages/mirai/lib/src/framework/mirai.dart
+++ b/packages/mirai/lib/src/framework/mirai.dart
@@ -122,3 +122,11 @@ class Mirai {
     return null;
   }
 }
+
+extension MiraiExtension on Widget? {
+  PreferredSizeWidget? get toPreferredSizeWidget {
+    if (this != null) {
+      return this as PreferredSizeWidget;
+    }
+  }
+}

--- a/packages/mirai/lib/src/framework/mirai.dart
+++ b/packages/mirai/lib/src/framework/mirai.dart
@@ -128,5 +128,6 @@ extension MiraiExtension on Widget? {
     if (this != null) {
       return this as PreferredSizeWidget;
     }
+    return null;
   }
 }

--- a/packages/mirai/lib/src/parsers/mirai_alert_dialog/mirai_alert_dialog_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_alert_dialog/mirai_alert_dialog_parser.dart
@@ -29,7 +29,7 @@ class MiraiAlertDialogParser extends MiraiParser<MiraiAlertDialog> {
       contentPadding: model.contentPadding.parse,
       contentTextStyle: model.contentTextStyle?.parse,
       actions: model.actions
-          ?.map((action) => Mirai.fromJson(action, context))
+          ?.map((action) => Mirai.fromJson(action, context) ?? const SizedBox())
           .toList(),
       actionsPadding: model.actionsPadding.parse,
       actionsAlignment: model.actionsAlignment,

--- a/packages/mirai/lib/src/parsers/mirai_app_bar/mirai_app_bar_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_app_bar/mirai_app_bar_parser.dart
@@ -26,7 +26,7 @@ class MiraiAppBarParser extends MiraiParser<MiraiAppBar> {
       foregroundColor: model.foregroundColor?.toColor,
       surfaceTintColor: model.surfaceTintColor?.toColor,
       actions: model.actions
-          .map((action) => Mirai.fromJson(action, context))
+          .map((action) => Mirai.fromJson(action, context) ?? const SizedBox())
           .toList(),
       titleSpacing: model.titleSpacing,
       toolbarOpacity: model.toolbarOpacity,

--- a/packages/mirai/lib/src/parsers/mirai_column/mirai_column_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_column/mirai_column_parser.dart
@@ -22,7 +22,7 @@ class MiraiColumnParser extends MiraiParser<MiraiColumn> {
       verticalDirection: model.verticalDirection,
       children: model.children
           .map(
-            (value) => Mirai.fromJson(value, context),
+            (value) => Mirai.fromJson(value, context) ?? const SizedBox(),
           )
           .toList(),
     );

--- a/packages/mirai/lib/src/parsers/mirai_default_tab_controller/mirai_default_tab_controller_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_default_tab_controller/mirai_default_tab_controller_parser.dart
@@ -18,7 +18,7 @@ class MiraiDefaultTabControllerParser
   Widget parse(BuildContext context, MiraiDefaultTabController model) {
     return DefaultTabController(
       length: model.length,
-      child: Mirai.fromJson(model.child, context),
+      child: Mirai.fromJson(model.child, context) ?? const SizedBox(),
     );
   }
 }

--- a/packages/mirai/lib/src/parsers/mirai_floating_action_button/mirai_floating_action_button_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_floating_action_button/mirai_floating_action_button_parser.dart
@@ -43,7 +43,7 @@ class MiraiFloatingActionButtonParser
           autofocus: model.autofocus,
           tooltip: model.tooltip,
           heroTag: model.heroTag,
-          label: Mirai.fromJson(model.child, context),
+          label: Mirai.fromJson(model.child, context) ?? const SizedBox(),
         );
 
       case FloatingActionButtonType.large:

--- a/packages/mirai/lib/src/parsers/mirai_icon_button/mirai_icon_button_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_icon_button/mirai_icon_button_parser.dart
@@ -38,7 +38,7 @@ class MiraiIconButtonParser extends MiraiParser<MiraiIconButton> {
       autofocus: model.autofocus,
       isSelected: model.isSelected,
       selectedIcon: Mirai.fromJson(model.selectedIcon, context),
-      icon: Mirai.fromJson(model.child, context),
+      icon: Mirai.fromJson(model.child, context) ?? const SizedBox(),
     );
   }
 

--- a/packages/mirai/lib/src/parsers/mirai_list_view/mirai_list_view_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_list_view/mirai_list_view_parser.dart
@@ -39,7 +39,7 @@ class MiraiListViewParser extends MiraiParser<MiraiListView> {
       itemBuilder: (context, index) =>
           Mirai.fromJson(model.children[index], context),
       separatorBuilder: (context, _) =>
-          Mirai.fromJson(model.separator, context),
+          Mirai.fromJson(model.separator, context) ?? const SizedBox(),
     );
   }
 }

--- a/packages/mirai/lib/src/parsers/mirai_navigation_bar_item/mirai_bottom_navigation_bar_item.dart
+++ b/packages/mirai/lib/src/parsers/mirai_navigation_bar_item/mirai_bottom_navigation_bar_item.dart
@@ -23,7 +23,7 @@ class MiraiBottomNavigationBarItem with _$MiraiBottomNavigationBarItem {
 extension MiraiBottomNavigationBarItemParser on MiraiBottomNavigationBarItem {
   BottomNavigationBarItem parse(BuildContext context) {
     return BottomNavigationBarItem(
-      icon: Mirai.fromJson(icon, context),
+      icon: Mirai.fromJson(icon, context) ?? const SizedBox(),
       activeIcon:
           activeIcon == null ? null : Mirai.fromJson(activeIcon, context),
       label: label,

--- a/packages/mirai/lib/src/parsers/mirai_row/mirai_row_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_row/mirai_row_parser.dart
@@ -21,7 +21,7 @@ class MiraiRowParser extends MiraiParser<MiraiRow> {
       textDirection: model.textDirection,
       verticalDirection: model.verticalDirection,
       children: model.children
-          .map((value) => Mirai.fromJson(value, context))
+          .map((value) => Mirai.fromJson(value, context) ?? const SizedBox())
           .toList(),
     );
   }

--- a/packages/mirai/lib/src/parsers/mirai_scaffold/mirai_scaffold_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_scaffold/mirai_scaffold_parser.dart
@@ -17,10 +17,7 @@ class MiraiScaffoldParser extends MiraiParser<MiraiScaffold> {
   @override
   Widget parse(BuildContext context, MiraiScaffold model) {
     return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size(double.maxFinite, 56),
-        child: Mirai.fromJson(model.appBar, context),
-      ),
+      appBar: Mirai.fromJson(model.appBar, context).toPreferredSizeWidget,
       body: Mirai.fromJson(model.body, context),
       floatingActionButton: Mirai.fromJson(model.floatingActionButton, context),
       floatingActionButtonLocation: model.floatingActionButtonLocation?.value,

--- a/packages/mirai/lib/src/parsers/mirai_tab_bar/mirai_tab_bar_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_tab_bar/mirai_tab_bar_parser.dart
@@ -21,7 +21,9 @@ class MiraiTabBarParser extends MiraiParser<MiraiTabBar> {
   Widget parse(BuildContext context, MiraiTabBar model) {
     return TabBar(
       controller: controller,
-      tabs: model.tabs.map((tab) => Mirai.fromJson(tab, context)).toList(),
+      tabs: model.tabs
+          .map((tab) => Mirai.fromJson(tab, context) ?? const SizedBox())
+          .toList(),
       isScrollable: model.isScrollable,
       padding: model.padding?.parse,
       indicatorColor: model.indicatorColor?.toColor,

--- a/packages/mirai/lib/src/parsers/mirai_tab_bar_view/mirai_tab_bar_view_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_tab_bar_view/mirai_tab_bar_view_parser.dart
@@ -24,7 +24,7 @@ class MiraiTabBarViewParser extends MiraiParser<MiraiTabBarView> {
       viewportFraction: model.viewportFraction,
       clipBehavior: model.clipBehavior,
       children: model.children
-          .map((child) => Mirai.fromJson(child, context))
+          .map((child) => Mirai.fromJson(child, context) ?? const SizedBox())
           .toList(),
     );
   }

--- a/packages/mirai/lib/src/parsers/mirai_text_button/mirai_text_button_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_text_button/mirai_text_button_parser.dart
@@ -28,7 +28,7 @@ class MiraiTextButtonParser extends MiraiParser<MiraiTextButton> {
       style: _style(model.style),
       autofocus: model.autofocus,
       clipBehavior: model.clipBehavior,
-      child: Mirai.fromJson(model.child, context),
+      child: Mirai.fromJson(model.child, context) ?? const SizedBox(),
     );
   }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR makes `Mirai.fromJson` return `Widget?` instead of `Widget`. And cast AppBar as PreferredSizeWidget.

## Related Issues

closes #80 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore