### PR TITLE
Allow inject a dio instance

### DIFF
--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -43,13 +43,18 @@ void main() async {
 }
 ```
 
-You can also specify your custom Parsers in `Mirai.initialize`.
+You can also specify your custom Parsers in `Mirai.initialize` and `Dio` instance.
 
 ```dart
 void main() async {
-  await Mirai.initialize(parsers: const [
-    ExampleScreenParser(),
-  ]);
+  final dio = Dio()
+
+  await Mirai.initialize(
+    parsers: const [
+      ExampleScreenParser(),
+    ],
+    dio: dio,
+  );
 
   runApp(const MyApp());
 }

--- a/packages/mirai/lib/src/framework/mirai.dart
+++ b/packages/mirai/lib/src/framework/mirai.dart
@@ -55,9 +55,11 @@ class Mirai {
 
   static Future<void> initialize({
     List<MiraiParser> parsers = const [],
+    Dio? dio,
   }) async {
     _parsers.addAll(parsers);
     MiraiRegistry.instance.registerAll(_parsers);
+    MiraiNetwork.initialize(dio ?? Dio());
   }
 
   static Widget? fromJson(Map<String, dynamic>? json, BuildContext context) {

--- a/packages/mirai/lib/src/network/mirai_network.dart
+++ b/packages/mirai/lib/src/network/mirai_network.dart
@@ -4,7 +4,9 @@ import 'package:mirai/src/network/mirai_request.dart';
 class MiraiNetwork {
   const MiraiNetwork._();
 
-  static final _dio = Dio();
+  static late Dio _dio;
+
+  static void initialize(Dio dio) => _dio = dio;
 
   static Future<Response?> request(MiraiRequest request) {
     switch (request.method) {


### PR DESCRIPTION
## Description

Allows Mirai to accept a Dio instance, which enables users to take full advantage of all the features provided by Dio, including powerful interceptors. By injecting a Dio instance, users can customize their HTTP requests and responses, add authentication headers, handle errors, and more. This improves the flexibility and robustness of the library's networking functionality.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore