### PR TITLE
refactor: Removed deprecated values `MaterialApp.router` in v3.10.0

### DIFF
--- a/examples/mirai_gallery/pubspec.lock
+++ b/examples/mirai_gallery/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   bloc:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "3709d74615bba5e443eb141f6a7f4bcc4788f8fae6f743edadfb79c2a8e6287e"
+      sha256: "347d56c26d63519552ef9a569f2a593dda99a81fdbdff13c584b7197cfe05059"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -311,10 +311,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
@@ -343,10 +343,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: c40f9ef51e5bffb4ce69ad2d8c8aad7bd47ec109c090521109b63a4e2bc27191
+      sha256: db2ff852ed77090ba9f62d3611e4208a3d11dfa35991a81ae724c113fcb3e3f7
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   logging:
     dependency: transitive
     description:
@@ -359,10 +359,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -375,10 +375,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -393,7 +393,7 @@ packages:
       path: "../../packages/mirai"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   nested:
     dependency: transitive
     description:
@@ -414,10 +414,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   pool:
     dependency: transitive
     description:
@@ -539,10 +539,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timing:
     dependency: transitive
     description:
@@ -592,5 +592,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.2 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/examples/mirai_gallery/pubspec.yaml
+++ b/examples/mirai_gallery/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.19.2 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/mirai/lib/src/framework/mirai_app.dart
+++ b/packages/mirai/lib/src/framework/mirai_app.dart
@@ -185,7 +185,6 @@ class MiraiApp extends StatelessWidget {
       restorationScopeId: restorationScopeId,
       scrollBehavior: scrollBehavior,
       debugShowMaterialGrid: debugShowMaterialGrid,
-      useInheritedMediaQuery: useInheritedMediaQuery,
     );
   }
 
@@ -223,7 +222,6 @@ class MiraiApp extends StatelessWidget {
       actions: actions,
       restorationScopeId: restorationScopeId,
       scrollBehavior: scrollBehavior,
-      useInheritedMediaQuery: useInheritedMediaQuery,
     );
   }
 }

--- a/packages/mirai/lib/src/parsers/mirai_alert_dialog/mirai_alert_dialog.dart
+++ b/packages/mirai/lib/src/parsers/mirai_alert_dialog/mirai_alert_dialog.dart
@@ -32,8 +32,10 @@ class MiraiAlertDialog with _$MiraiAlertDialog {
     String? semanticLabel,
     @Default(MiraiEdgeInsets(left: 40, right: 40, top: 24, bottom: 24))
         MiraiEdgeInsets insetPadding,
-    @Default(Clip.none) Clip clipBehavior,
-    @Default(false) bool scrollable,
+    @Default(Clip.none)
+        Clip clipBehavior,
+    @Default(false)
+        bool scrollable,
   }) = _MiraiAlertDialog;
 
   factory MiraiAlertDialog.fromJson(Map<String, dynamic> json) =>

--- a/packages/mirai/lib/src/parsers/mirai_floating_action_button/mirai_floating_action_button.dart
+++ b/packages/mirai/lib/src/parsers/mirai_floating_action_button/mirai_floating_action_button.dart
@@ -15,7 +15,8 @@ class MiraiFloatingActionButton with _$MiraiFloatingActionButton {
     MiraiTextStyle? textStyle,
     @Default(FloatingActionButtonType.small)
         FloatingActionButtonType buttonType,
-    @Default(false) bool autofocus,
+    @Default(false)
+        bool autofocus,
     Map<String, dynamic>? icon,
     String? backgroundColor,
     String? foregroundColor,

--- a/packages/mirai/lib/src/parsers/mirai_list_view/mirai_list_view.dart
+++ b/packages/mirai/lib/src/parsers/mirai_list_view/mirai_list_view.dart
@@ -12,24 +12,33 @@ part 'mirai_list_view.g.dart';
 @freezed
 class MiraiListView with _$MiraiListView {
   const factory MiraiListView({
-    @Default(Axis.vertical) Axis scrollDirection,
-    @Default(false) bool reverse,
+    @Default(Axis.vertical)
+        Axis scrollDirection,
+    @Default(false)
+        bool reverse,
     bool? primary,
     MiraiScrollPhysics? physics,
-    @Default(false) bool shrinkWrap,
+    @Default(false)
+        bool shrinkWrap,
     MiraiEdgeInsets? padding,
-    @Default(true) bool addAutomaticKeepAlives,
-    @Default(true) bool addRepaintBoundaries,
-    @Default(true) bool addSemanticIndexes,
+    @Default(true)
+        bool addAutomaticKeepAlives,
+    @Default(true)
+        bool addRepaintBoundaries,
+    @Default(true)
+        bool addSemanticIndexes,
     double? cacheExtent,
-    @Default([]) List<Map<String, dynamic>> children,
+    @Default([])
+        List<Map<String, dynamic>> children,
     Map<String, dynamic>? separator,
     int? semanticChildCount,
-    @Default(DragStartBehavior.start) DragStartBehavior dragStartBehavior,
+    @Default(DragStartBehavior.start)
+        DragStartBehavior dragStartBehavior,
     @Default(ScrollViewKeyboardDismissBehavior.manual)
         ScrollViewKeyboardDismissBehavior keyboardDismissBehavior,
     String? restorationId,
-    @Default(Clip.hardEdge) Clip clipBehavior,
+    @Default(Clip.hardEdge)
+        Clip clipBehavior,
   }) = _MiraiListView;
 
   factory MiraiListView.fromJson(Map<String, dynamic> json) =>

--- a/packages/mirai/lib/src/parsers/mirai_scroll_view/mirai_scroll_view.dart
+++ b/packages/mirai/lib/src/parsers/mirai_scroll_view/mirai_scroll_view.dart
@@ -12,14 +12,18 @@ part 'mirai_scroll_view.g.dart';
 @freezed
 class MiraiScrollView with _$MiraiScrollView {
   const factory MiraiScrollView({
-    @Default(Axis.vertical) Axis scrollDirection,
-    @Default(false) bool reverse,
+    @Default(Axis.vertical)
+        Axis scrollDirection,
+    @Default(false)
+        bool reverse,
     MiraiEdgeInsets? padding,
     bool? primary,
     MiraiScrollPhysics? physics,
     Map<String, dynamic>? child,
-    @Default(DragStartBehavior.start) DragStartBehavior dragStartBehavior,
-    @Default(Clip.hardEdge) Clip clipBehavior,
+    @Default(DragStartBehavior.start)
+        DragStartBehavior dragStartBehavior,
+    @Default(Clip.hardEdge)
+        Clip clipBehavior,
     String? restorationId,
     @Default(ScrollViewKeyboardDismissBehavior.manual)
         ScrollViewKeyboardDismissBehavior keyboardDismissBehavior,

--- a/packages/mirai/lib/src/parsers/mirai_stack/mirai_stack.dart
+++ b/packages/mirai/lib/src/parsers/mirai_stack/mirai_stack.dart
@@ -12,10 +12,13 @@ class MiraiStack with _$MiraiStack {
   const factory MiraiStack({
     @Default(MiraiAlignmentDirectional.topStart)
         MiraiAlignmentDirectional alignment,
-    @Default(Clip.hardEdge) Clip clipBehavior,
-    @Default(StackFit.loose) StackFit fit,
+    @Default(Clip.hardEdge)
+        Clip clipBehavior,
+    @Default(StackFit.loose)
+        StackFit fit,
     TextDirection? textDirection,
-    @Default([]) List<Map<String, dynamic>> children,
+    @Default([])
+        List<Map<String, dynamic>> children,
   }) = _MiraiStack;
 
   factory MiraiStack.fromJson(Map<String, dynamic> json) =>

--- a/packages/mirai/lib/src/parsers/mirai_text_form_field/mirai_text_form_field.dart
+++ b/packages/mirai/lib/src/parsers/mirai_text_form_field/mirai_text_form_field.dart
@@ -20,38 +20,51 @@ class MiraiTextFormField with _$MiraiTextFormField {
     String? initialValue,
     MiraiTextInputType? keyboardType,
     TextInputAction? textInputAction,
-    @Default(TextCapitalization.none) TextCapitalization textCapitalization,
+    @Default(TextCapitalization.none)
+        TextCapitalization textCapitalization,
     MiraiTextStyle? style,
-    @Default(TextAlign.start) TextAlign textAlign,
+    @Default(TextAlign.start)
+        TextAlign textAlign,
     MiraiTextAlignVertical? textAlignVertical,
     TextDirection? textDirection,
-    @Default(false) bool readOnly,
+    @Default(false)
+        bool readOnly,
     bool? showCursor,
-    @Default(false) bool autofocus,
-    @Default('•') String obscuringCharacter,
+    @Default(false)
+        bool autofocus,
+    @Default('•')
+        String obscuringCharacter,
     int? maxLines,
     int? minLines,
     int? maxLength,
-    @Default(false) bool obscureText,
-    @Default(true) bool autocorrect,
+    @Default(false)
+        bool obscureText,
+    @Default(true)
+        bool autocorrect,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
     MaxLengthEnforcement? maxLengthEnforcement,
-    @Default(false) bool expands,
+    @Default(false)
+        bool expands,
     Brightness? keyboardAppearance,
     @Default(MiraiEdgeInsets(bottom: 20, top: 20, left: 20, right: 20))
         MiraiEdgeInsets scrollPadding,
     String? restorationId,
-    @Default(true) bool enableIMEPersonalizedLearning,
-    @Default(true) bool enableSuggestions,
+    @Default(true)
+        bool enableIMEPersonalizedLearning,
+    @Default(true)
+        bool enableSuggestions,
     bool? enabled,
-    @Default(2) double cursorWidth,
+    @Default(2)
+        double cursorWidth,
     double? cursorHeight,
     String? cursorColor,
     String? hintText,
     AutovalidateMode? autovalidateMode,
-    @Default([]) List<MiraiInputFormatter> inputFormatters,
-    @Default([]) List<MiraiFormFieldValidator> validatorRules,
+    @Default([])
+        List<MiraiInputFormatter> inputFormatters,
+    @Default([])
+        List<MiraiFormFieldValidator> validatorRules,
   }) = _MiraiTextFormField;
 
   factory MiraiTextFormField.fromJson(Map<String, dynamic> json) =>

--- a/packages/mirai/pubspec.yaml
+++ b/packages/mirai/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 homepage: https://github.com/Securrency-OSS/mirai.git
 
 environment:
-  sdk: ">=2.17.1 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
@@ -14,7 +14,6 @@ dependencies:
   json_annotation: ^4.8.0
   logger: ^1.3.0
   dio: ^5.1.1
-
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Removed deprecated values `MaterialApp.router` in v3.10.0

## Related Issues

<!--- List the related issues to this PR -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore