### PR TITLE
feat: Add support to `each` action

### DIFF
--- a/packages/mirai/lib/src/action_parsers/action_parsers.dart
+++ b/packages/mirai/lib/src/action_parsers/action_parsers.dart
@@ -1,3 +1,4 @@
+export 'package:mirai/src/action_parsers/mirai_each_action/mirai_each_action_parser.dart';
 export 'package:mirai/src/action_parsers/mirai_navigate_action/mirai_navigate_action_parser.dart';
 export 'package:mirai/src/action_parsers/mirai_none_action/mirai_none_action_parser.dart';
 export 'package:mirai/src/action_parsers/mirai_request_action/mirai_request_action_parser.dart';

--- a/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action.dart
+++ b/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'mirai_each_action.freezed.dart';
+part 'mirai_each_action.g.dart';
+
+@freezed
+class MiraiEachAction with _$MiraiEachAction {
+  const MiraiEachAction._();
+
+  factory MiraiEachAction({
+    required List<Map<String, dynamic>> actions,
+  }) = _MiraiEachAction;
+
+  factory MiraiEachAction.fromJson(Map<String, dynamic> json) =>
+      _$MiraiEachActionFromJson(json);
+}

--- a/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action.freezed.dart
+++ b/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action.freezed.dart
@@ -1,0 +1,161 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mirai_each_action.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+MiraiEachAction _$MiraiEachActionFromJson(Map<String, dynamic> json) {
+  return _MiraiEachAction.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MiraiEachAction {
+  List<Map<String, dynamic>> get actions => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MiraiEachActionCopyWith<MiraiEachAction> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MiraiEachActionCopyWith<$Res> {
+  factory $MiraiEachActionCopyWith(
+          MiraiEachAction value, $Res Function(MiraiEachAction) then) =
+      _$MiraiEachActionCopyWithImpl<$Res, MiraiEachAction>;
+  @useResult
+  $Res call({List<Map<String, dynamic>> actions});
+}
+
+/// @nodoc
+class _$MiraiEachActionCopyWithImpl<$Res, $Val extends MiraiEachAction>
+    implements $MiraiEachActionCopyWith<$Res> {
+  _$MiraiEachActionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? actions = null,
+  }) {
+    return _then(_value.copyWith(
+      actions: null == actions
+          ? _value.actions
+          : actions // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_MiraiEachActionCopyWith<$Res>
+    implements $MiraiEachActionCopyWith<$Res> {
+  factory _$$_MiraiEachActionCopyWith(
+          _$_MiraiEachAction value, $Res Function(_$_MiraiEachAction) then) =
+      __$$_MiraiEachActionCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<Map<String, dynamic>> actions});
+}
+
+/// @nodoc
+class __$$_MiraiEachActionCopyWithImpl<$Res>
+    extends _$MiraiEachActionCopyWithImpl<$Res, _$_MiraiEachAction>
+    implements _$$_MiraiEachActionCopyWith<$Res> {
+  __$$_MiraiEachActionCopyWithImpl(
+      _$_MiraiEachAction _value, $Res Function(_$_MiraiEachAction) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? actions = null,
+  }) {
+    return _then(_$_MiraiEachAction(
+      actions: null == actions
+          ? _value._actions
+          : actions // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, dynamic>>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_MiraiEachAction extends _MiraiEachAction {
+  _$_MiraiEachAction({required final List<Map<String, dynamic>> actions})
+      : _actions = actions,
+        super._();
+
+  factory _$_MiraiEachAction.fromJson(Map<String, dynamic> json) =>
+      _$$_MiraiEachActionFromJson(json);
+
+  final List<Map<String, dynamic>> _actions;
+  @override
+  List<Map<String, dynamic>> get actions {
+    if (_actions is EqualUnmodifiableListView) return _actions;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_actions);
+  }
+
+  @override
+  String toString() {
+    return 'MiraiEachAction(actions: $actions)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_MiraiEachAction &&
+            const DeepCollectionEquality().equals(other._actions, _actions));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_actions));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_MiraiEachActionCopyWith<_$_MiraiEachAction> get copyWith =>
+      __$$_MiraiEachActionCopyWithImpl<_$_MiraiEachAction>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_MiraiEachActionToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MiraiEachAction extends MiraiEachAction {
+  factory _MiraiEachAction(
+      {required final List<Map<String, dynamic>> actions}) = _$_MiraiEachAction;
+  _MiraiEachAction._() : super._();
+
+  factory _MiraiEachAction.fromJson(Map<String, dynamic> json) =
+      _$_MiraiEachAction.fromJson;
+
+  @override
+  List<Map<String, dynamic>> get actions;
+  @override
+  @JsonKey(ignore: true)
+  _$$_MiraiEachActionCopyWith<_$_MiraiEachAction> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action.g.dart
+++ b/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mirai_each_action.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_MiraiEachAction _$$_MiraiEachActionFromJson(Map<String, dynamic> json) =>
+    _$_MiraiEachAction(
+      actions: (json['actions'] as List<dynamic>)
+          .map((e) => e as Map<String, dynamic>)
+          .toList(),
+    );
+
+Map<String, dynamic> _$$_MiraiEachActionToJson(_$_MiraiEachAction instance) =>
+    <String, dynamic>{
+      'actions': instance.actions,
+    };

--- a/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action_parser.dart
+++ b/packages/mirai/lib/src/action_parsers/mirai_each_action/mirai_each_action_parser.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:mirai/src/action_parsers/mirai_each_action/mirai_each_action.dart';
+import 'package:mirai/src/framework/framework.dart';
+import 'package:mirai/src/utils/action_type.dart';
+
+class MiraiEachActionParser extends MiraiActionParser<MiraiEachAction> {
+  const MiraiEachActionParser();
+
+  @override
+  String get type => ActionType.each.name;
+
+  @override
+  MiraiEachAction getModel(Map<String, dynamic> json) =>
+      MiraiEachAction.fromJson(json);
+
+  @override
+  FutureOr<dynamic> onCall(BuildContext context, MiraiEachAction model) async {
+    for (var element in model.actions) {
+      await Mirai.onCallFromJson(element, context);
+    }
+  }
+}

--- a/packages/mirai/lib/src/framework/mirai.dart
+++ b/packages/mirai/lib/src/framework/mirai.dart
@@ -63,6 +63,7 @@ class Mirai {
     const MiraiNoneActionParser(),
     const MiraiNavigateActionParser(),
     const MiraiRequestActionParser(),
+    const MiraiEachActionParser(),
   ];
 
   static Future<void> initialize({

--- a/packages/mirai/lib/src/utils/action_type.dart
+++ b/packages/mirai/lib/src/utils/action_type.dart
@@ -2,4 +2,5 @@ enum ActionType {
   navigate,
   none,
   request,
+  each,
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The idea of this action is to allow the user to perform sequential actions when necessary. For example, when the user clicks on a button, this action should show a toast and send a request to the server.
Or copy something to the clipboard and show a dialog.

So we can declare this like that:

```json
{
  "type": "textButton",
  "child": {
    "type": "text",
    "data": "BUTTON"
  },
  "onPressed": {
    "actionType": "each",
    "actions": [
      {
        "actionType": "copyToClipBoard",
        "value": "Some value"
      },
      {
        "actionType": "showToast",
        "value": "Value copied to clipboard"
      },
      {
        "actionType": "vibrate",
        "pattern": [0, 1, 1, 0, 1, 0, 1, 1, 1]
      }
    ]
  }
}
```

## Related Issues

<!--- List the related issues to this PR -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore