### PR TITLE
:bug: fix: Failed assertion 'initialValue == null || controller == null': is not true in TextFormField

### DIFF
--- a/packages/mirai/lib/src/parsers/mirai_text_form_field/mirai_text_form_field_parser.dart
+++ b/packages/mirai/lib/src/parsers/mirai_text_form_field/mirai_text_form_field_parser.dart
@@ -73,7 +73,6 @@ class __TextFormFieldWidgetState extends State<_TextFormFieldWidget> {
               );
         }
       },
-      initialValue: widget.model.initialValue,
       keyboardType: widget.model.keyboardType?.value,
       textInputAction: widget.model.textInputAction,
       textCapitalization: widget.model.textCapitalization,


### PR DESCRIPTION
## Description
:bug: removed multiple assignment of initial value in MiraiTextFormField

Closes #188 
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore