### PR TITLE
feat: Added a new way to redefine how we declare EdgeInsets

### DIFF
--- a/packages/mirai/lib/src/action_parsers/mirai_dialog_action/mirai_dialog_action.g.dart
+++ b/packages/mirai/lib/src/action_parsers/mirai_dialog_action/mirai_dialog_action.g.dart
@@ -40,5 +40,4 @@ Map<String, dynamic> _$$MiraiDialogActionImplToJson(
 const _$TraversalEdgeBehaviorEnumMap = {
   TraversalEdgeBehavior.closedLoop: 'closedLoop',
   TraversalEdgeBehavior.leaveFlutterView: 'leaveFlutterView',
-  TraversalEdgeBehavior.parentScope: 'parentScope',
 };

--- a/packages/mirai/lib/src/action_parsers/mirai_dialog_action/mirai_dialog_action.g.dart
+++ b/packages/mirai/lib/src/action_parsers/mirai_dialog_action/mirai_dialog_action.g.dart
@@ -40,4 +40,5 @@ Map<String, dynamic> _$$MiraiDialogActionImplToJson(
 const _$TraversalEdgeBehaviorEnumMap = {
   TraversalEdgeBehavior.closedLoop: 'closedLoop',
   TraversalEdgeBehavior.leaveFlutterView: 'leaveFlutterView',
+  TraversalEdgeBehavior.parentScope: 'parentScope',
 };

--- a/packages/mirai/lib/src/parsers/mirai_alert_dialog/mirai_alert_dialog.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_alert_dialog/mirai_alert_dialog.g.dart
@@ -12,14 +12,12 @@ _$MiraiAlertDialogImpl _$$MiraiAlertDialogImplFromJson(
       icon: json['icon'] as Map<String, dynamic>?,
       iconPadding: json['iconPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['iconPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['iconPadding']),
       iconColor: json['iconColor'] as String?,
       title: json['title'] as Map<String, dynamic>?,
       titlePadding: json['titlePadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['titlePadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['titlePadding']),
       titleTextStyle: json['titleTextStyle'] == null
           ? null
           : MiraiTextStyle.fromJson(
@@ -27,8 +25,7 @@ _$MiraiAlertDialogImpl _$$MiraiAlertDialogImplFromJson(
       content: json['content'] as Map<String, dynamic>?,
       contentPadding: json['contentPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['contentPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['contentPadding']),
       contentTextStyle: json['contentTextStyle'] == null
           ? null
           : MiraiTextStyle.fromJson(
@@ -38,8 +35,7 @@ _$MiraiAlertDialogImpl _$$MiraiAlertDialogImplFromJson(
           .toList(),
       actionsPadding: json['actionsPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['actionsPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['actionsPadding']),
       actionsAlignment: $enumDecodeNullable(
           _$MainAxisAlignmentEnumMap, json['actionsAlignment']),
       actionsOverflowAlignment: $enumDecodeNullable(
@@ -50,15 +46,13 @@ _$MiraiAlertDialogImpl _$$MiraiAlertDialogImplFromJson(
           (json['actionsOverflowButtonSpacing'] as num?)?.toDouble(),
       buttonPadding: json['buttonPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['buttonPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['buttonPadding']),
       backgroundColor: json['backgroundColor'] as String?,
       elevation: (json['elevation'] as num?)?.toDouble(),
       semanticLabel: json['semanticLabel'] as String?,
       insetPadding: json['insetPadding'] == null
           ? const MiraiEdgeInsets(left: 40, right: 40, top: 24, bottom: 24)
-          : MiraiEdgeInsets.fromJson(
-              json['insetPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['insetPadding']),
       clipBehavior:
           $enumDecodeNullable(_$ClipEnumMap, json['clipBehavior']) ?? Clip.none,
       scrollable: json['scrollable'] as bool? ?? false,

--- a/packages/mirai/lib/src/parsers/mirai_bottom_app_bar_theme/mirai_bottom_app_bar_theme.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_bottom_app_bar_theme/mirai_bottom_app_bar_theme.g.dart
@@ -16,7 +16,7 @@ _$MiraiBottomAppBarThemeImpl _$$MiraiBottomAppBarThemeImplFromJson(
       shadowColor: json['shadowColor'] as String?,
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
     );
 
 Map<String, dynamic> _$$MiraiBottomAppBarThemeImplToJson(

--- a/packages/mirai/lib/src/parsers/mirai_button_style/mirai_button_style.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_button_style/mirai_button_style.g.dart
@@ -23,7 +23,7 @@ _$MiraiButtonStyleImpl _$$MiraiButtonStyleImplFromJson(
           : MiraiTextStyle.fromJson(json['textStyle'] as Map<String, dynamic>),
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       minimumSize: json['minimumSize'] == null
           ? null
           : MiraiSize.fromJson(json['minimumSize'] as Map<String, dynamic>),

--- a/packages/mirai/lib/src/parsers/mirai_card/mirai_card.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_card/mirai_card.g.dart
@@ -15,7 +15,7 @@ _$MiraiCardImpl _$$MiraiCardImplFromJson(Map<String, dynamic> json) =>
       borderOnForeground: json['borderOnForeground'] as bool? ?? true,
       margin: json['margin'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['margin'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['margin']),
       clipBehavior: $enumDecodeNullable(_$ClipEnumMap, json['clipBehavior']),
       child: json['child'] as Map<String, dynamic>?,
       semanticContainer: json['semanticContainer'] as bool? ?? true,

--- a/packages/mirai/lib/src/parsers/mirai_card_theme_data/mirai_card_theme_data.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_card_theme_data/mirai_card_theme_data.g.dart
@@ -16,7 +16,7 @@ _$MiraiCardThemeDataImpl _$$MiraiCardThemeDataImplFromJson(
       elevation: (json['elevation'] as num?)?.toDouble(),
       margin: json['margin'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['margin'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['margin']),
       shape: json['shape'] == null
           ? null
           : MiraiBorder.fromJson(json['shape'] as Map<String, dynamic>),

--- a/packages/mirai/lib/src/parsers/mirai_chip/mirai_chip.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_chip/mirai_chip.g.dart
@@ -15,8 +15,7 @@ _$MiraiChipImpl _$$MiraiChipImplFromJson(Map<String, dynamic> json) =>
           : MiraiTextStyle.fromJson(json['labelStyle'] as Map<String, dynamic>),
       labelPadding: json['labelPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['labelPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['labelPadding']),
       deleteIcon: json['deleteIcon'] as Map<String, dynamic>?,
       deleteIconColor: json['deleteIconColor'] as String?,
       deleteButtonTooltipMessage: json['deleteButtonTooltipMessage'] as String?,
@@ -32,7 +31,7 @@ _$MiraiChipImpl _$$MiraiChipImplFromJson(Map<String, dynamic> json) =>
       backgroundColor: json['backgroundColor'] as String?,
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       elevation: (json['elevation'] as num?)?.toDouble(),
       shadowColor: json['shadowColor'] as String?,
       surfaceTintColor: json['surfaceTintColor'] as String?,

--- a/packages/mirai/lib/src/parsers/mirai_container/mirai_container.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_container/mirai_container.g.dart
@@ -12,7 +12,7 @@ _$MiraiContainerImpl _$$MiraiContainerImplFromJson(Map<String, dynamic> json) =>
           $enumDecodeNullable(_$MiraiAlignmentEnumMap, json['alignment']),
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       decoration: json['decoration'] == null
           ? null
           : MiraiBoxDecoration.fromJson(
@@ -22,7 +22,7 @@ _$MiraiContainerImpl _$$MiraiContainerImplFromJson(Map<String, dynamic> json) =>
       height: (json['height'] as num?)?.toDouble(),
       margin: json['margin'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['margin'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['margin']),
       child: json['child'] as Map<String, dynamic>?,
       clipBehavior:
           $enumDecodeNullable(_$ClipEnumMap, json['clipBehavior']) ?? Clip.none,

--- a/packages/mirai/lib/src/parsers/mirai_dialog_theme/mirai_dialog_theme.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_dialog_theme/mirai_dialog_theme.g.dart
@@ -30,8 +30,7 @@ _$MiraiDialogThemeImpl _$$MiraiDialogThemeImplFromJson(
               json['contentTextStyle'] as Map<String, dynamic>),
       actionsPadding: json['actionsPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['actionsPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['actionsPadding']),
       iconColor: json['iconColor'] as String?,
     );
 

--- a/packages/mirai/lib/src/parsers/mirai_edge_insets/mirai_edge_insets.dart
+++ b/packages/mirai/lib/src/parsers/mirai_edge_insets/mirai_edge_insets.dart
@@ -25,7 +25,11 @@ class MiraiEdgeInsets with _$MiraiEdgeInsets {
         "right": json,
         "bottom": json
       };
-    } else if (json is List<num> && json.length == 4) {
+    } else if (json is List<dynamic> && json.length == 4) {
+      bool allElementsNum = json.every((element) => element is num);
+      if (!allElementsNum) {
+        throw ArgumentError('Invalid input format for MiraiEdgeInsets');
+      }
       resultantJson = {
         "left": json[0],
         "top": json[1],

--- a/packages/mirai/lib/src/parsers/mirai_edge_insets/mirai_edge_insets.dart
+++ b/packages/mirai/lib/src/parsers/mirai_edge_insets/mirai_edge_insets.dart
@@ -13,8 +13,33 @@ class MiraiEdgeInsets with _$MiraiEdgeInsets {
     double? bottom,
   }) = _MiraiEdgeInsets;
 
-  factory MiraiEdgeInsets.fromJson(Map<String, dynamic> json) =>
-      _$MiraiEdgeInsetsFromJson(json);
+  factory MiraiEdgeInsets.fromJson(dynamic json) => _fromJson(json);
+
+  static MiraiEdgeInsets _fromJson(dynamic json) {
+    Map<String, dynamic> resultantJson;
+
+    if (json is num) {
+      resultantJson = {
+        "left": json,
+        "top": json,
+        "right": json,
+        "bottom": json
+      };
+    } else if (json is List<num> && json.length == 4) {
+      resultantJson = {
+        "left": json[0],
+        "top": json[1],
+        "right": json[2],
+        "bottom": json[3]
+      };
+    } else if (json is Map<String, dynamic>) {
+      resultantJson = json;
+    } else {
+      throw ArgumentError('Invalid input format for MiraiEdgeInsets');
+    }
+
+    return _$MiraiEdgeInsetsFromJson(resultantJson);
+  }
 }
 
 extension MiraiEdgeInsetsParser on MiraiEdgeInsets? {

--- a/packages/mirai/lib/src/parsers/mirai_floating_action_button_theme_data/mirai_floating_action_button_theme_data.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_floating_action_button_theme_data/mirai_floating_action_button_theme_data.g.dart
@@ -26,8 +26,7 @@ _$MiraiFloatingActionButtonThemeDataImpl
               (json['extendedIconLabelSpacing'] as num?)?.toDouble(),
           extendedPadding: json['extendedPadding'] == null
               ? null
-              : MiraiEdgeInsets.fromJson(
-                  json['extendedPadding'] as Map<String, dynamic>),
+              : MiraiEdgeInsets.fromJson(json['extendedPadding']),
           extendedTextStyle: json['extendedTextStyle'] == null
               ? null
               : MiraiTextStyle.fromJson(

--- a/packages/mirai/lib/src/parsers/mirai_grid_view/mirai_grid_view.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_grid_view/mirai_grid_view.g.dart
@@ -18,7 +18,7 @@ _$MiraiGridViewImpl _$$MiraiGridViewImplFromJson(Map<String, dynamic> json) =>
       shrinkWrap: json['shrinkWrap'] as bool? ?? false,
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       crossAxisCount: json['crossAxisCount'] as int?,
       mainAxisSpacing: (json['mainAxisSpacing'] as num?)?.toDouble() ?? 0.0,
       crossAxisSpacing: (json['crossAxisSpacing'] as num?)?.toDouble() ?? 0.0,

--- a/packages/mirai/lib/src/parsers/mirai_icon_button/mirai_icon_button.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_icon_button/mirai_icon_button.g.dart
@@ -13,7 +13,7 @@ _$MiraiIconButtonImpl _$$MiraiIconButtonImplFromJson(
       iconSize: (json['iconSize'] as num?)?.toDouble(),
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       alignment:
           $enumDecodeNullable(_$MiraiAlignmentEnumMap, json['alignment']) ??
               MiraiAlignment.center,

--- a/packages/mirai/lib/src/parsers/mirai_input_decoration/mirai_input_decoration.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_input_decoration/mirai_input_decoration.g.dart
@@ -46,8 +46,7 @@ _$MiraiInputDecorationImpl _$$MiraiInputDecorationImplFromJson(
       isDense: json['isDense'] as bool? ?? false,
       contentPadding: json['contentPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['contentPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['contentPadding']),
       prefixIcon: json['prefixIcon'] as Map<String, dynamic>?,
       prefixIconConstraints: json['prefixIconConstraints'] == null
           ? null

--- a/packages/mirai/lib/src/parsers/mirai_input_decoration_theme/mirai_input_decoration_theme.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_input_decoration_theme/mirai_input_decoration_theme.g.dart
@@ -35,8 +35,7 @@ _$MiraiInputDecorationThemeImpl _$$MiraiInputDecorationThemeImplFromJson(
       isDense: json['isDense'] as bool? ?? false,
       contentPadding: json['contentPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['contentPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['contentPadding']),
       isCollapsed: json['isCollapsed'] as bool? ?? false,
       iconColor: json['iconColor'] as String?,
       prefixStyle: json['prefixStyle'] == null

--- a/packages/mirai/lib/src/parsers/mirai_list_tile/mirai_list_tile.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_list_tile/mirai_list_tile.g.dart
@@ -22,8 +22,7 @@ _$MiraiListTileImpl _$$MiraiListTileImplFromJson(Map<String, dynamic> json) =>
       textColor: json['textColor'] as String?,
       contentPadding: json['contentPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['contentPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['contentPadding']),
       enabled: json['enabled'] as bool? ?? true,
       selected: json['selected'] as bool? ?? false,
       focusColor: json['focusColor'] as String?,

--- a/packages/mirai/lib/src/parsers/mirai_list_tile_theme_data/mirai_list_tile_theme_data.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_list_tile_theme_data/mirai_list_tile_theme_data.g.dart
@@ -31,8 +31,7 @@ _$MiraiListTileThemeDataImpl _$$MiraiListTileThemeDataImplFromJson(
               json['leadingAndTrailingTextStyle'] as Map<String, dynamic>),
       contentPadding: json['contentPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['contentPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['contentPadding']),
       tileColor: json['tileColor'] as String?,
       selectedTileColor: json['selectedTileColor'] as String?,
       horizontalTitleGap: (json['horizontalTitleGap'] as num?)?.toDouble(),

--- a/packages/mirai/lib/src/parsers/mirai_list_view/mirai_list_view.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_list_view/mirai_list_view.g.dart
@@ -18,7 +18,7 @@ _$MiraiListViewImpl _$$MiraiListViewImplFromJson(Map<String, dynamic> json) =>
       shrinkWrap: json['shrinkWrap'] as bool? ?? false,
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       addAutomaticKeepAlives: json['addAutomaticKeepAlives'] as bool? ?? true,
       addRepaintBoundaries: json['addRepaintBoundaries'] as bool? ?? true,
       addSemanticIndexes: json['addSemanticIndexes'] as bool? ?? true,

--- a/packages/mirai/lib/src/parsers/mirai_padding/mirai_padding.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_padding/mirai_padding.g.dart
@@ -8,8 +8,7 @@ part of 'mirai_padding.dart';
 
 _$MiraiPaddingImpl _$$MiraiPaddingImplFromJson(Map<String, dynamic> json) =>
     _$MiraiPaddingImpl(
-      padding:
-          MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+      padding: MiraiEdgeInsets.fromJson(json['padding']),
       child: json['child'] as Map<String, dynamic>?,
     );
 

--- a/packages/mirai/lib/src/parsers/mirai_safe_area/mirai_safe_area.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_safe_area/mirai_safe_area.g.dart
@@ -15,7 +15,7 @@ _$MiraiSafeAreaImpl _$$MiraiSafeAreaImplFromJson(Map<String, dynamic> json) =>
       bottom: json['bottom'] as bool? ?? true,
       minimum: json['minimum'] == null
           ? const MiraiEdgeInsets()
-          : MiraiEdgeInsets.fromJson(json['minimum'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['minimum']),
       maintainBottomViewPadding:
           json['maintainBottomViewPadding'] as bool? ?? false,
     );

--- a/packages/mirai/lib/src/parsers/mirai_single_child_scroll_view/mirai_single_child_scroll_view.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_single_child_scroll_view/mirai_single_child_scroll_view.g.dart
@@ -15,7 +15,7 @@ _$MiraiSingleChildScrollViewImpl _$$MiraiSingleChildScrollViewImplFromJson(
       reverse: json['reverse'] as bool? ?? false,
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       primary: json['primary'] as bool?,
       physics:
           $enumDecodeNullable(_$MiraiScrollPhysicsEnumMap, json['physics']),

--- a/packages/mirai/lib/src/parsers/mirai_tab/mirai_tab.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_tab/mirai_tab.g.dart
@@ -12,8 +12,7 @@ _$MiraiTabImpl _$$MiraiTabImplFromJson(Map<String, dynamic> json) =>
       icon: json['icon'] as Map<String, dynamic>?,
       iconMargin: json['iconMargin'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['iconMargin'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['iconMargin']),
       height: (json['height'] as num?)?.toDouble(),
       child: json['child'] as Map<String, dynamic>?,
     );

--- a/packages/mirai/lib/src/parsers/mirai_tab_bar/mirai_tab_bar.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_tab_bar/mirai_tab_bar.g.dart
@@ -15,15 +15,14 @@ _$MiraiTabBarImpl _$$MiraiTabBarImplFromJson(Map<String, dynamic> json) =>
       isScrollable: json['isScrollable'] as bool? ?? false,
       padding: json['padding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(json['padding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['padding']),
       indicatorColor: json['indicatorColor'] as String?,
       automaticIndicatorColorAdjustment:
           json['automaticIndicatorColorAdjustment'] as bool? ?? true,
       indicatorWeight: (json['indicatorWeight'] as num?)?.toDouble() ?? 2.0,
       indicatorPadding: json['indicatorPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['indicatorPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['indicatorPadding']),
       indicatorSize: $enumDecodeNullable(
           _$TabBarIndicatorSizeEnumMap, json['indicatorSize']),
       labelColor: json['labelColor'] as String?,
@@ -32,8 +31,7 @@ _$MiraiTabBarImpl _$$MiraiTabBarImplFromJson(Map<String, dynamic> json) =>
           : MiraiTextStyle.fromJson(json['labelStyle'] as Map<String, dynamic>),
       labelPadding: json['labelPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['labelPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['labelPadding']),
       unselectedLabelColor: json['unselectedLabelColor'] as String?,
       unselectedLabelStyle: json['unselectedLabelStyle'] == null
           ? null

--- a/packages/mirai/lib/src/parsers/mirai_tab_bar_theme_data/mirai_tab_bar_theme_data.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_tab_bar_theme_data/mirai_tab_bar_theme_data.g.dart
@@ -20,8 +20,7 @@ _$MiraiTabBarThemeDataImpl _$$MiraiTabBarThemeDataImplFromJson(
       labelColor: json['labelColor'] as String?,
       labelPadding: json['labelPadding'] == null
           ? null
-          : MiraiEdgeInsets.fromJson(
-              json['labelPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['labelPadding']),
       labelStyle: json['labelStyle'] == null
           ? null
           : MiraiTextStyle.fromJson(json['labelStyle'] as Map<String, dynamic>),

--- a/packages/mirai/lib/src/parsers/mirai_text_form_field/mirai_text_form_field.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_text_form_field/mirai_text_form_field.g.dart
@@ -52,8 +52,7 @@ _$MiraiTextFormFieldImpl _$$MiraiTextFormFieldImplFromJson(
           $enumDecodeNullable(_$BrightnessEnumMap, json['keyboardAppearance']),
       scrollPadding: json['scrollPadding'] == null
           ? const MiraiEdgeInsets(bottom: 20, top: 20, left: 20, right: 20)
-          : MiraiEdgeInsets.fromJson(
-              json['scrollPadding'] as Map<String, dynamic>),
+          : MiraiEdgeInsets.fromJson(json['scrollPadding']),
       restorationId: json['restorationId'] as String?,
       enableIMEPersonalizedLearning:
           json['enableIMEPersonalizedLearning'] as bool? ?? true,


### PR DESCRIPTION
## Description

Previously, there was only one way to define `MiraiEdgeInsets` and it looked like this

```
              "padding": {
                "top": 8,
                "left": 12,
                "right": 12,
                "bottom": 8
              }
```

In this pull request, I have added the two new ways as suggested to declare `MiraiEdgeInsets`. 

1. To give the same padding to all directions, you can now just write like this. 

```
              "padding": 10, 
```

2. To give padding to all directions, but in a better and more concise way, you can now just write it like this. 

```
              "padding": [10, 12, 12, 10]
```


To approach this issue, I have defined a new static method inside `MiraiEdgeInsets` named `_fromJson` that takes a `dynamic` argument and checks if the type of argument is among three acceptable types i.e. `num, List<num>, Map<String, dynamic>`, and returns `MiraiEdgeInsets`; otherwise, throw an `ArgumentError`. 

## Related Issues

Closes #260 

## Screen Recording

https://github.com/Securrency-OSS/mirai/assets/92971894/6396a9b4-71fd-4272-a5ce-28cb173999e3



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
