### PR TITLE
feat: Added a new way to redefine how we declare BorderRadius

### DIFF
--- a/examples/mirai_gallery/assets/json/text_field_example.json
+++ b/examples/mirai_gallery/assets/json/text_field_example.json
@@ -246,12 +246,7 @@
               "labelText": "Gradient TextField",
               "border": {
                 "type": "outlineInputBorder",
-                "borderRadius": {
-                  "topLeft": 8,
-                  "topRight": 8,
-                  "bottomLeft": 8,
-                  "bottomRight": 8
-                },
+                "borderRadius": 80,
                 "gradient": {
                   "colors": [
                     "#FF0000",

--- a/packages/mirai/lib/src/parsers/mirai_border_radius/mirai_border_radius.dart
+++ b/packages/mirai/lib/src/parsers/mirai_border_radius/mirai_border_radius.dart
@@ -13,8 +13,37 @@ class MiraiBorderRadius with _$MiraiBorderRadius {
     @Default(0.0) double bottomRight,
   }) = _MiraiBorder;
 
-  factory MiraiBorderRadius.fromJson(Map<String, dynamic> json) =>
-      _$MiraiBorderRadiusFromJson(json);
+  factory MiraiBorderRadius.fromJson(dynamic json) => _fromJson(json);
+
+  static MiraiBorderRadius _fromJson(dynamic json) {
+    Map<String, dynamic> resultantJson;
+
+    if (json is num) {
+      resultantJson = {
+        "topLeft": json,
+        "topRight": json,
+        "bottomLeft": json,
+        "bottomRight": json
+      };
+    } else if (json is List<dynamic> && json.length == 4) {
+      bool allElementsNum = json.every((element) => element is num);
+      if (!allElementsNum) {
+        throw ArgumentError('Invalid input format for MiraiEdgeInsets');
+      }
+      resultantJson = {
+        "topLeft": json[0],
+        "topRight": json[1],
+        "bottomLeft": json[2],
+        "bottomRight": json[3]
+      };
+    } else if (json is Map<String, dynamic>) {
+      resultantJson = json;
+    } else {
+      throw ArgumentError('Invalid input format for MiraiEdgeInsets');
+    }
+
+    return _$MiraiBorderRadiusFromJson(resultantJson);
+  }
 }
 
 extension MiraiBorderRadiusParser on MiraiBorderRadius? {

--- a/packages/mirai/lib/src/parsers/mirai_box_decoration/mirai_box_decoration.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_box_decoration/mirai_box_decoration.g.dart
@@ -24,8 +24,7 @@ _$MiraiBoxDecorationImpl _$$MiraiBoxDecorationImplFromJson(
           : MiraiBorder.fromJson(json['border'] as Map<String, dynamic>),
       borderRadius: json['borderRadius'] == null
           ? null
-          : MiraiBorderRadius.fromJson(
-              json['borderRadius'] as Map<String, dynamic>),
+          : MiraiBorderRadius.fromJson(json['borderRadius']),
       image: json['image'] == null
           ? null
           : MiraiDecorationImage.fromJson(

--- a/packages/mirai/lib/src/parsers/mirai_input_border/mirai_input_border.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_input_border/mirai_input_border.g.dart
@@ -13,8 +13,7 @@ _$MiraiInputBorderImpl _$$MiraiInputBorderImplFromJson(
           MiraiInputBorderType.underlineInputBorder,
       borderRadius: json['borderRadius'] == null
           ? null
-          : MiraiBorderRadius.fromJson(
-              json['borderRadius'] as Map<String, dynamic>),
+          : MiraiBorderRadius.fromJson(json['borderRadius']),
       gapPadding: (json['gapPadding'] as num?)?.toDouble() ?? 4.0,
       width: (json['width'] as num?)?.toDouble() ?? 0.0,
       color: json['color'] as String?,

--- a/packages/mirai/lib/src/parsers/mirai_rounded_rectangle_border/mirai_rounded_rectangle_border.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_rounded_rectangle_border/mirai_rounded_rectangle_border.g.dart
@@ -14,8 +14,7 @@ _$MiraiRoundedRectangleBorderImpl _$$MiraiRoundedRectangleBorderImplFromJson(
           : MiraiBorderSide.fromJson(json['side'] as Map<String, dynamic>),
       borderRadius: json['borderRadius'] == null
           ? null
-          : MiraiBorderRadius.fromJson(
-              json['borderRadius'] as Map<String, dynamic>),
+          : MiraiBorderRadius.fromJson(json['borderRadius']),
     );
 
 Map<String, dynamic> _$$MiraiRoundedRectangleBorderImplToJson(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

 Added a new way to redefine how we declare BorderRadius.

Previoudly we could define the border radius in only one possible way:

```
              "borderRadius": {
                "topLeft": 8,
                "topRight": 8,
                "bottomLeft": 8,
                "bottomRight": 8
              }
```

Now you can pass double value to give border-radius to all:

```
              "borderRadius": 8,
```

or define all borderRadius in single line.

```
              "borderRadius": [8, 12, 8, 12],
```


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
